### PR TITLE
Fix legacy install detecter (still needs to look for WLinux)

### DIFF
--- a/debian/preinst
+++ b/debian/preinst
@@ -29,7 +29,7 @@ case "$1" in
 		# non-legacy installs. On legacy installs we also need to
 		# remove our previous /etc/profile modifications and delete
 		# old wlinux/pengwin scripts
-		if grep -Fq "Pengwin" /etc/os-release ; then
+		if grep -Fq "WLinux" /etc/os-release ; then
 			if [ -f "/etc/setup" ] ; then
 			if [ -f "/etc/helpme" ] ; then
 			echo "Pengwin legacy install detected"


### PR DESCRIPTION
Legacy install detecter changed search string to 'Pengwin', but we still need to look for 'WLinux' within os-release to detect legacy installs.