### PR TITLE
Windows home link

### DIFF
--- a/profile.d/00-pengwin.sh
+++ b/profile.d/00-pengwin.sh
@@ -15,6 +15,21 @@ alias ll='ls -al'
 
 # Execute on user's shell first-run
 if [ ! -f "${HOME}/.firstrun" ]; then
-    echo "Welcome to Pengwin. Type 'pengwin-setup' to run the setup tool. You will only see this message on the first run"
-    touch "${HOME}/.firstrun"
+  echo "Welcome to Pengwin. Type 'pengwin-setup' to run the setup tool. You will only see this message on the first run"
+  touch "${HOME}/.firstrun"
 fi
+
+function create_winhome_link() {
+
+  # Create a symbolic link to the windows home
+  local wHomeWinPath=$(cmd.exe /c 'echo %HOMEDRIVE%%HOMEPATH%' 2>&1 | tr -d '\r')
+  export WIN_HOME=$(wslpath -u "${wHomeWinPath}")
+
+  local win_home_lnk=${HOME}/winhome
+  if [ ! -e "${win_home_lnk}" ] ; then
+    ln -s -f "${WIN_HOME}" "${win_home_lnk}"
+  fi
+
+}
+
+create_winhome_link


### PR DESCRIPTION
Automatically creates and updates a symbolic link to the user's windows home called winhome. Also leaves an environment variable with the windows home path in WIN_HOME