### PR TITLE
Add empty case for required args in postrm

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -63,6 +63,9 @@ case "$1" in
 		echo "Your previous profile can be found at /etc/profile.old"
 	;;
 
+	upgrade|failed-upgrade|abort-upgrade)
+	;;
+
 	*)
 		echo "postrm called with unknown argument \`$1'" >&2
 		exit 1


### PR DESCRIPTION
Stops failure on upgrades.

Signed-off-by: kim (grufwub) <grufwub@gmail.com>