### PR TITLE
Some last fixes for 1.2 release

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -63,7 +63,7 @@ case "$1" in
 		rm -rf ${TMPDIR}
 
 		# This is a new install, create dist-upgrade flag file
-		touch "${FLAGFILE}"
+		# touch "${FLAGFILE}"
 	;;
 
 	abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/postinst
+++ b/debian/postinst
@@ -60,7 +60,6 @@ case "$1" in
 
 		# Remove temporary directory
 		echo "Cleaning up pengwin-base temporary install dir"
-		cd ${CURDIR}
 		rm -rf ${TMPDIR}
 
 		# This is a new install, create dist-upgrade flag file

--- a/debian/preinst
+++ b/debian/preinst
@@ -19,7 +19,7 @@ case "$1" in
 		TMPDIR="/run/dpkg.pengwin-base.inst"
 
 		# Ensure all necessary filesystem directories exist
-		mkdir -p /etcfonts
+		mkdir -p /etc/fonts
 		mkdir -p /etc/profile.d
 		mkdir -p /etc/apt/sources.list.d
 		mkdir -p /etc/dpkg/origins


### PR DESCRIPTION
- remove `rm ${CURDIR}` from postinst, this is leftover code from previous iteration of postinst
- comment out `touch ${FLAGFILE}` in postinst as in our current situation of release we don't need to trigger a distribution upgrade
- correct typo `mkdir -p /etc/fonts` in preinst