### PR TITLE
HOTFIX wslpath behavior

### DIFF
--- a/profile.d/00-pengwin.sh
+++ b/profile.d/00-pengwin.sh
@@ -22,7 +22,7 @@ if ( which cmd.exe >/dev/null ); then
     touch "${HOME}/.firstrun"
   fi
 
-  if ( ! wslpath > /dev/null 2>&1 ); then
+  if ( ! wslpath 'C:\' > /dev/null 2>&1 ); then
     alias wslpath=legacy_wslupath
   fi
 


### PR DESCRIPTION
This error was forcing users of newer Windows version to use legacy wslupath designed for older ones in place of the real wslpath