### PR TITLE
#365 [Pengwin-365] Missing OS release info for npm

### DIFF
--- a/os-release
+++ b/os-release
@@ -1,6 +1,10 @@
 PRETTY_NAME="Pengwin"
 NAME="Pengwin"
+VERSION_ID="10"
+VERSION="10 (buster)"
 ID=debian
+ID_LIKE=debian
 HOME_URL="https://github.com/whitewaterfoundry/Pengwin"
 SUPPORT_URL="https://github.com/whitewaterfoundry/Pengwin"
 BUG_REPORT_URL="https://github.com/whitewaterfoundry/Pengwin"
+VERSION_CODENAME=buster


### PR DESCRIPTION
With this change, running with node:

```
const osInfo = require('linux-os-info')
var result = osInfo({mode: 'sync'})
console.log(`You are using ${result.pretty_name} on a ${result.arch} machine`)
console.log(result);
```

gives:

```
You are using Pengwin on a x64 machine
{
  type: 'Linux',
  platform: 'linux',
  hostname: 'desktop',
  arch: 'x64',
  release: '4.4.0-17763-Microsoft',
  file: '/etc/os-release',
  pretty_name: 'Pengwin',
  name: 'Pengwin',
  version_id: '10',
  version: '10 (buster)',
  id: 'debian',
  id_like: 'debian',
  home_url: 'https://github.com/whitewaterfoundry/Pengwin',
  support_url: 'https://github.com/whitewaterfoundry/Pengwin',
  bug_report_url: 'https://github.com/whitewaterfoundry/Pengwin',
  version_codename: 'buster'
}
```

