### PR TITLE
Support cross distro automount in wsl2 for Docker Desktop

### DIFF
--- a/wsl.conf
+++ b/wsl.conf
@@ -2,6 +2,7 @@
 enabled = true
 options = "metadata,uid=1000,gid=1000,umask=22,fmask=11,case=off"
 mountFsTab = true
+crossDistro = true
 
 [network]
 generateHosts = true


### PR DESCRIPTION
From the [release notes of Build 18970](https://docs.microsoft.com/en-us/windows/wsl/release-notes#build-18970):

> [WSL2] Support Docker Desktop by creating cross distro mounts. A distro can opt-in to this behavior by adding the following line to the /etc/wsl.conf file:

```
[automount]
crossDistro = true
```