### PR TITLE
Skip some steps in 00-pengwin.fish for non-interactive sessions

### DIFF
--- a/fish_conf.d/00-pengwin.fish
+++ b/fish_conf.d/00-pengwin.fish
@@ -52,7 +52,7 @@ alias clear='clear -x'
 alias ll='ls -al'
 
 # Check if we have Windows Path
-if which cmd.exe >/dev/null
+if which cmd.exe >/dev/null; and status --is-login
 
   # Execute on user's shell first-run
   if test ! -f "$HOME/.firstrun"


### PR DESCRIPTION
The sub-shell command that sets `wHomeWinPath` breaks `ProxyJump` in SSH; we don't need to do it for non interactive/login shells so skip it in that case.
Fixes WhitewaterFoundry/Pengwin#712